### PR TITLE
Task identifier support

### DIFF
--- a/Sources/DVR/SessionDataTask.swift
+++ b/Sources/DVR/SessionDataTask.swift
@@ -11,7 +11,7 @@ final class SessionDataTask: URLSessionDataTask {
 
     weak var session: Session!
     let request: URLRequest
-    let injectedIdentifier: Int
+    private let injectedIdentifier: Int
     let completion: Completion?
     private let queue = DispatchQueue(label: "com.venmo.DVR.sessionDataTaskQueue", attributes: [])
     private var interaction: Interaction?

--- a/Sources/DVR/SessionDataTask.swift
+++ b/Sources/DVR/SessionDataTask.swift
@@ -11,6 +11,7 @@ final class SessionDataTask: URLSessionDataTask {
 
     weak var session: Session!
     let request: URLRequest
+    let injectedIdentifier: Int
     let completion: Completion?
     private let queue = DispatchQueue(label: "com.venmo.DVR.sessionDataTaskQueue", attributes: [])
     private var interaction: Interaction?
@@ -19,12 +20,16 @@ final class SessionDataTask: URLSessionDataTask {
         return interaction?.response
     }
 
+    override var taskIdentifier: Int {
+        return injectedIdentifier
+    }
 
     // MARK: - Initializers
 
-    init(session: Session, request: URLRequest, completion: (Completion)? = nil) {
+    init(session: Session, request: URLRequest, taskIdentifier: Int, completion: (Completion)? = nil) {
         self.session = session
         self.request = request
+        self.injectedIdentifier = taskIdentifier
         self.completion = completion
     }
 

--- a/Sources/DVR/SessionDownloadTask.swift
+++ b/Sources/DVR/SessionDownloadTask.swift
@@ -33,7 +33,6 @@ final class SessionDownloadTask: URLSessionDownloadTask {
     }
 
     override func resume() {
-        // same ID?
         let task = SessionDataTask(session: session, request: request, taskIdentifier: session.nextTaskIdentifier()) { data, response, error in
             let location: URL?
             if let data = data {

--- a/Sources/DVR/SessionDownloadTask.swift
+++ b/Sources/DVR/SessionDownloadTask.swift
@@ -10,14 +10,19 @@ final class SessionDownloadTask: URLSessionDownloadTask {
 
     weak var session: Session!
     let request: URLRequest
+    private let injectedIdentifier: Int
     let completion: Completion?
 
+    override var taskIdentifier: Int {
+        return injectedIdentifier
+    }
 
     // MARK: - Initializers
 
-    init(session: Session, request: URLRequest, completion: Completion? = nil) {
+    init(session: Session, request: URLRequest, taskIdentifier: Int, completion: Completion? = nil) {
         self.session = session
         self.request = request
+        self.injectedIdentifier = taskIdentifier
         self.completion = completion
     }
 
@@ -28,7 +33,8 @@ final class SessionDownloadTask: URLSessionDownloadTask {
     }
 
     override func resume() {
-        let task = SessionDataTask(session: session, request: request) { data, response, error in
+        // same ID?
+        let task = SessionDataTask(session: session, request: request, taskIdentifier: session.nextTaskIdentifier()) { data, response, error in
             let location: URL?
             if let data = data {
                 // Write data to temporary file

--- a/Sources/DVR/SessionUploadTask.swift
+++ b/Sources/DVR/SessionUploadTask.swift
@@ -10,16 +10,22 @@ final class SessionUploadTask: URLSessionUploadTask {
 
     weak var session: Session!
     let request: URLRequest
+    private let injectedIdentifier: Int
     let completion: Completion?
     let dataTask: SessionDataTask
 
+    override var taskIdentifier: Int {
+        return injectedIdentifier
+    }
+
     // MARK: - Initializers
 
-    init(session: Session, request: URLRequest, completion: Completion? = nil) {
+    init(session: Session, request: URLRequest, taskIdentifier: Int, completion: Completion? = nil) {
         self.session = session
         self.request = request
+        self.injectedIdentifier = taskIdentifier
         self.completion = completion
-        dataTask = SessionDataTask(session: session, request: request, completion: completion)
+        dataTask = SessionDataTask(session: session, request: request, taskIdentifier: session.nextTaskIdentifier(), completion: completion)
     }
 
     // MARK: - URLSessionTask


### PR DESCRIPTION
DVR provides a subclass of `URLSessionTask` which needs to override `taskIdentifier` to prevent crashing

This is implemented similar to [Apple's open source `URLSession` implementation](https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/URLSession/URLSession.swift)