### PR TITLE
Task/DMA-3324: fix crashes and swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.4
+osx_image: xcode10.2
 xcode_project: DVR.xcodeproj
 
 matrix:
@@ -7,7 +7,7 @@ matrix:
     - xcode_scheme: DVR-iOS
       xcode_sdk: iphonesimulator
       env:
-        - DESTINATION="iOS Simulator,OS=11.4,name=iPhone X"
+        - DESTINATION="iOS Simulator,OS=12.2,name=iPhone X"
     - xcode_scheme: DVR-macOS
       xcode_sdk: macosx
       env:
@@ -15,7 +15,7 @@ matrix:
     - xcode_scheme: DVR-tvOS
       xcode_sdk: appletvsimulator
       env:
-        - DESTINATION="tvOS Simulator,name=Apple TV 4K,OS=11.4"
+        - DESTINATION="tvOS Simulator,name=Apple TV 4K,OS=12.2"
     - env:
       - SWIFT_BUILD=true
 

--- a/DVR.podspec
+++ b/DVR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'DVR'
-  s.version          = '1.3.2'
+  s.version          = '2.0.1'
   s.summary          = 'Network testing for Swift'
   s.description      = <<-DESC
 DVR is a simple Swift framework for making fake NSURLSession requests for iOS, watchOS, and OS X based on VCR.

--- a/DVR.xcodeproj/project.pbxproj
+++ b/DVR.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0810;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1120;
 				ORGANIZATIONNAME = Venmo;
 				TargetAttributes = {
 					2104F52D1DC658580039CA14 = {
@@ -440,11 +440,11 @@
 					};
 					3647AF9A1B335D5500EF10D4 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1120;
 					};
 					3647AFA41B335D5500EF10D4 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1120;
 					};
 					3690A07A1B33AA3B00731222 = {
 						CreatedOnToolsVersion = 7.0;
@@ -461,6 +461,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 3647AF911B335D5500EF10D4;
@@ -727,6 +728,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -791,6 +793,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -859,7 +862,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.DVR;
 				PRODUCT_NAME = DVR;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.1;
 			};
 			name = Debug;
 		};
@@ -878,7 +881,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.DVR;
 				PRODUCT_NAME = DVR;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.1;
 			};
 			name = Release;
 		};
@@ -890,7 +893,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.DVR.iostests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.1;
 			};
 			name = Debug;
 		};
@@ -902,7 +905,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.DVR.iostests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.1;
 			};
 			name = Release;
 		};

--- a/DVR.xcodeproj/xcshareddata/xcschemes/DVR-iOS.xcscheme
+++ b/DVR.xcodeproj/xcshareddata/xcschemes/DVR-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3647AF9A1B335D5500EF10D4"
+            BuildableName = "DVR.framework"
+            BlueprintName = "DVR-iOS"
+            ReferencedContainer = "container:DVR.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,17 +49,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "3647AF9A1B335D5500EF10D4"
-            BuildableName = "DVR.framework"
-            BlueprintName = "DVR-iOS"
-            ReferencedContainer = "container:DVR.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +69,6 @@
             ReferencedContainer = "container:DVR.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/DVR.xcodeproj/xcshareddata/xcschemes/DVR-macOS.xcscheme
+++ b/DVR.xcodeproj/xcshareddata/xcschemes/DVR-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3690A07A1B33AA3B00731222"
+            BuildableName = "DVR.framework"
+            BlueprintName = "DVR-macOS"
+            ReferencedContainer = "container:DVR.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "3690A07A1B33AA3B00731222"
-            BuildableName = "DVR.framework"
-            BlueprintName = "DVR-macOS"
-            ReferencedContainer = "container:DVR.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:DVR.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/DVR.xcodeproj/xcshareddata/xcschemes/DVR-tvOS.xcscheme
+++ b/DVR.xcodeproj/xcshareddata/xcschemes/DVR-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2104F52D1DC658580039CA14"
+            BuildableName = "DVR.framework"
+            BlueprintName = "DVR-tvOS"
+            ReferencedContainer = "container:DVR.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "2104F52D1DC658580039CA14"
-            BuildableName = "DVR.framework"
-            BlueprintName = "DVR-tvOS"
-            ReferencedContainer = "container:DVR.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:DVR.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/DVR/Resources/Info.plist
+++ b/Sources/DVR/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.2</string>
+	<string>2.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/DVR/Session.swift
+++ b/Sources/DVR/Session.swift
@@ -40,6 +40,14 @@ open class Session: URLSession {
 
 
     // MARK: - URLSession
+    
+    open override func dataTask(with url: URL) -> URLSessionDataTask {
+        return addDataTask(URLRequest(url: url))
+    }
+
+    open override func dataTask(with url: URL, completionHandler: @escaping ((Data?, Foundation.URLResponse?, Error?) -> Void)) -> URLSessionDataTask {
+        return addDataTask(URLRequest(url: url), completionHandler: completionHandler)
+    }
 
     open override func dataTask(with request: URLRequest) -> URLSessionDataTask {
         return addDataTask(request)
@@ -129,7 +137,7 @@ open class Session: URLSession {
     func finishTask(_ task: URLSessionTask, interaction: Interaction, playback: Bool) {
         needsPersistence = needsPersistence || !playback
 
-        if let index = outstandingTasks.index(of: task) {
+        if let index = outstandingTasks.firstIndex(of: task) {
             outstandingTasks.remove(at: index)
         }
 

--- a/Sources/DVR/SessionDataTask.swift
+++ b/Sources/DVR/SessionDataTask.swift
@@ -24,6 +24,18 @@ final class SessionDataTask: URLSessionDataTask {
         return injectedIdentifier
     }
 
+    override var currentRequest: URLRequest? {
+        return request
+    }
+
+    public override var priority: Float {
+        get {
+             return URLSessionTask.defaultPriority
+        }
+        set {
+        }
+    }
+
     // MARK: - Initializers
 
     init(session: Session, request: URLRequest, taskIdentifier: Int, completion: (Completion)? = nil) {

--- a/Tests/DVRTests/SessionTests.swift
+++ b/Tests/DVRTests/SessionTests.swift
@@ -27,11 +27,39 @@ class SessionTests: XCTestCase {
         } else {
             XCTFail()
         }
+
+        XCTAssertEqual(dataTask.currentRequest?.url?.absoluteString, request.url?.absoluteString)
     }
 
     func testDataTaskWithCompletion() {
         let request = URLRequest(url: URL(string: "http://example.com")!)
         let dataTask = session.dataTask(with: request, completionHandler: { _, _, _ in return }) 
+        
+        XCTAssert(dataTask is SessionDataTask)
+        
+        if let dataTask = dataTask as? SessionDataTask, let headers = dataTask.request.allHTTPHeaderFields {
+            XCTAssert(headers["testSessionHeader"] == "testSessionHeaderValue")
+        } else {
+            XCTFail()
+        }
+    }
+    
+    func testDataTaskWithUrl() {
+        let url = URL(string: "http://example.com")!
+        let dataTask = session.dataTask(with: url)
+        
+        XCTAssert(dataTask is SessionDataTask)
+        
+        if let dataTask = dataTask as? SessionDataTask, let headers = dataTask.request.allHTTPHeaderFields {
+            XCTAssert(headers["testSessionHeader"] == "testSessionHeaderValue")
+        } else {
+            XCTFail()
+        }
+    }
+
+    func testDataTaskWithUrlAndCompletion() {
+        let url = URL(string: "http://example.com")!
+        let dataTask = session.dataTask(with: url, completionHandler: { _, _, _ in return })
         
         XCTAssert(dataTask is SessionDataTask)
         


### PR DESCRIPTION
- update travis config,
- forward delegateQueue through to the backing session,
- fix "[Session defaultTaskGroup]: unrecognized selector sent to instance" for Swift 5.1,
- expose currentRequest in SessionDataTask